### PR TITLE
Simplify Debian repo configuration

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,3 +81,6 @@ telegraf_win_service_args:
   - -service install
   - -config {{ telegraf_win_install_dir }}\telegraf\telegraf.conf
   - --config-directory {{ telegraf_win_include }}
+
+telegraf_deb_repo_base: "https://repos.influxdata.com"
+telegraf_deb_repo_string: "deb {{ telegraf_deb_repo_base }}/{{ ansible_distribution|lower }} {{ ansible_lsb.codename|default(ansible_distribution_release) }} stable"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -48,26 +48,14 @@
   when:
     - telegraf_agent_package_method == "repo"
 
-- name: "Debian | Add Telegraf repository (using LSB)"
-  apt_repository:
-    repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_lsb.codename }} stable"
-    filename: "telegraf"
-    state: present
-  become: yes
-  when:
-    - telegraf_agent_package_method == "repo"
-    - ansible_lsb is defined
-    - ansible_lsb.codename is defined
-
 - name: "Debian | Add Telegraf repository"
   apt_repository:
-    repo: "deb https://repos.influxdata.com/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} stable"
+    repo: "{{ telegraf_deb_repo_string }}"
     filename: "telegraf"
     state: present
   become: yes
   when:
     - telegraf_agent_package_method == "repo"
-    - ansible_lsb is not defined or ansible_lsb.codename is not defined
 
 - name: "Debian | Download Telegraf package (online)"
   get_url:


### PR DESCRIPTION
**Description of PR**

Instead of two separate steps this implements the fallback to
`ansible_distribution_release` via default variable definition. This somewhat
simplifies the playbook and as side effect allows user to override the
repository URL.

**Type of change**

Feature Pull Request